### PR TITLE
Update SDL_CreateRenderer for non-gpu acceleration devices

### DIFF
--- a/src/Display/display.c
+++ b/src/Display/display.c
@@ -160,10 +160,14 @@ int showWindow( ) {
       return 1;
     }
 
-    renderer = SDL_CreateRenderer( window, -1, SDL_RENDERER_ACCELERATED );
-    if ( NULL == renderer ) {
-      SDL_Log("Could not create renderer");
-      return 1;
+    renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+    if (renderer == NULL) {
+      SDL_Log("Hardware-accelerated renderer failed, trying software renderer: %s", SDL_GetError());
+      renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
+      if (renderer == NULL) {
+        SDL_Log("Could not create renderer: %s", SDL_GetError());
+        return 1;
+      }
     }
 
 


### PR DESCRIPTION
Some devices don’t support SDL_RENDERER_ACCELERATED
So, if the accelerated does not works, we will use SDL_RENDERER_SOFTWARE